### PR TITLE
fix: connect should use peer id in bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cids": "~0.5.6",
     "err-code": "^1.1.2",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p-daemon": "~0.1.0",
+    "libp2p-daemon": "~0.1.1",
     "multiaddr": "^6.0.0",
     "peer-id": "~0.12.0",
     "peer-info": "~0.15.0"

--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,7 @@ class Client {
     const request = {
       type: Request.Type.CONNECT,
       connect: {
-        peer: Buffer.from(peerId.toB58String()),
+        peer: peerId.toBytes(),
         addrs: addrs.map((a) => a.buffer)
       }
     }


### PR DESCRIPTION
Needs:

- [x] [libp2p/js-libp2p-daemon#6](https://github.com/libp2p/js-libp2p-daemon/pull/6)