### PR TITLE
fix: update code to work with latest daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs
 *.log
 
 coverage
+.nyc_output
 
 # Runtime data
 pids

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "sinon": "^7.2.2"
   },
   "dependencies": {
-    "cids": "~0.5.6",
+    "cids": "~0.5.7",
     "err-code": "^1.1.2",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p-daemon": "~0.1.3",
-    "multiaddr": "^6.0.0",
-    "peer-id": "~0.12.0",
-    "peer-info": "~0.15.0"
+    "libp2p-daemon": "github:libp2p/js-libp2p-daemon#feat/multiaddr-listen",
+    "multiaddr": "^6.0.5",
+    "peer-id": "~0.12.2",
+    "peer-info": "~0.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cids": "~0.5.7",
     "err-code": "^1.1.2",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p-daemon": "github:libp2p/js-libp2p-daemon#feat/multiaddr-listen",
+    "libp2p-daemon": "github:libp2p/js-libp2p-daemon#master",
     "multiaddr": "^6.0.5",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cids": "~0.5.7",
     "err-code": "^1.1.2",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
-    "libp2p-daemon": "github:libp2p/js-libp2p-daemon#master",
+    "libp2p-daemon": "~0.2.0",
     "multiaddr": "^6.0.5",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1"

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,8 @@ class Client {
       writable: true,
       allowHalfOpen: true
     })
-    this.socket.on('error', (err) => {
-      console.log(err)
+    this.socket.on('error', (_) => {
+      this.close()
     })
     this.dht = new DHT(this)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -249,12 +249,12 @@ class Client {
   /**
    * Register a handler for inbound streams on a given protocol
    *
-   * @param {string} path
+   * @param {Multiaddr} addr
    * @param {string} protocol
    */
-  async registerStreamHandler (path, protocol) {
-    if (typeof path !== 'string') {
-      throw errcode('invalid path received', 'ERR_INVALID_PATH')
+  async registerStreamHandler (addr, protocol) {
+    if (!multiaddr.isMultiaddr(addr)) {
+      throw errcode('invalid multiaddr received', 'ERR_INVALID_MULTIADDR')
     }
 
     if (typeof protocol !== 'string') {
@@ -265,7 +265,7 @@ class Client {
       type: Request.Type.STREAM_HANDLER,
       streamOpen: null,
       streamHandler: {
-        path,
+        addr: addr.buffer,
         proto: [protocol]
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,9 @@ class Client {
       writable: true,
       allowHalfOpen: true
     })
+    this.socket.on('error', (err) => {
+      console.log(err)
+    })
     this.dht = new DHT(this)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@
 
 const net = require('net')
 const Socket = net.Socket
-const path = require('path')
 const PeerID = require('peer-id')
 const multiaddr = require('multiaddr')
 const { encode, decode } = require('length-prefixed-stream')
@@ -11,16 +10,17 @@ const errcode = require('err-code')
 
 const DHT = require('./dht')
 const { ends } = require('./util/iterator')
+const { multiaddrToNetConfig } = require('./util')
 
 const LIMIT = 1 << 22 // 4MB
 
 class Client {
   /**
    * @constructor
-   * @param {String} socketPath unix socket path
+   * @param {Multiaddr} addr Multiaddr for the client to connect to
    */
-  constructor (socketPath) {
-    this.path = path.resolve(socketPath)
+  constructor (addr) {
+    this.multiaddr = addr
     this.server = null
     this.socket = new Socket({
       readable: true,
@@ -37,7 +37,8 @@ class Client {
    */
   attach () {
     return new Promise((resolve, reject) => {
-      this.socket.connect(this.path, (err) => {
+      const options = multiaddrToNetConfig(this.multiaddr)
+      this.socket.connect(options, (err) => {
         if (err) return reject(err)
         resolve()
       })
@@ -47,21 +48,21 @@ class Client {
   /**
    * Starts a server listening at `socketPath`. New connections
    * will be sent to the `connectionHandler`.
-   * @param {string} socketPath
+   * @param {Multiaddr} addr
    * @param {function(Stream)} connectionHandler
    * @returns {Promise}
    */
-  async startServer (socketPath, connectionHandler) {
+  async startServer (addr, connectionHandler) {
     if (this.server) {
       await this.stopServer()
     }
-
     return new Promise((resolve, reject) => {
       this.server = net.createServer({
         allowHalfOpen: true
       }, connectionHandler)
 
-      this.server.listen(path.resolve(socketPath), (err) => {
+      const options = multiaddrToNetConfig(addr)
+      this.server.listen(options, (err) => {
         if (err) return reject(err)
         resolve()
       })

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ class Client {
     await this.stopServer()
 
     return new Promise((resolve) => {
+      if (this.socket.destroyed) return resolve()
       this.socket.end(resolve)
     })
   }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -4,7 +4,7 @@ const { resolve } = require('path')
 
 /**
  * Converts the multiaddr to a nodejs NET compliant option
- * for .coonect or .listen
+ * for .connect or .listen
  * @param {Multiaddr} addr
  * @returns {string|object} A nodejs NET compliant option
  */

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { resolve } = require('path')
+
+/**
+ * Converts the multiaddr to a nodejs NET compliant option
+ * for .coonect or .listen
+ * @param {Multiaddr} addr
+ * @returns {string|object} A nodejs NET compliant option
+ */
+function multiaddrToNetConfig (addr) {
+  const listenPath = addr.getPath()
+  // unix socket listening
+  if (listenPath) {
+    return resolve(listenPath)
+  }
+  // tcp listening
+  return addr.nodeAddress()
+}
+
+module.exports.multiaddrToNetConfig = multiaddrToNetConfig

--- a/test/dht.spec.js
+++ b/test/dht.spec.js
@@ -268,7 +268,7 @@ describe('daemon dht client', function () {
       }
     })
 
-    it('should error if it cannot find the peer', async () => {
+    it('should error if it cannot find the peer', (done) => {
       PeerID.create({ bits: 512 }, async (err, peerId) => {
         expect(err).to.not.exist()
         client = new Client(defaultMultiaddr)
@@ -281,6 +281,7 @@ describe('daemon dht client', function () {
           expect(err).to.exist()
           expect(err.code).to.equal('ERR_DHT_FIND_PEER_FAILED')
         }
+        done()
       })
     })
   })
@@ -546,7 +547,7 @@ describe('daemon dht client', function () {
     let daemonB
     let client
 
-    before(async function () {
+    before(async () => {
       [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
@@ -558,8 +559,8 @@ describe('daemon dht client', function () {
       ])
     })
 
-    after(function () {
-      return Promise.all([
+    after(async () => {
+      await Promise.all([
         daemonA.stop(),
         daemonB.stop()
       ])
@@ -605,7 +606,7 @@ describe('daemon dht client', function () {
       expect(result).to.exist()
     })
 
-    it('should error if it cannot find the peer', async () => {
+    it('should error if it cannot find the peer', (done) => {
       PeerID.create({ bits: 512 }, async (err, peerId) => {
         expect(err).to.not.exist()
         client = new Client(defaultMultiaddr)
@@ -616,6 +617,8 @@ describe('daemon dht client', function () {
           await client.dht.getPublicKey(peerId)
         } catch (err) {
           expect(err).to.exist()
+        } finally {
+          done()
         }
       })
     })

--- a/test/dht.spec.js
+++ b/test/dht.spec.js
@@ -130,8 +130,8 @@ describe('daemon dht client', function () {
       await daemon.start()
     })
 
-    after(() => {
-      return daemon.stop()
+    after(async () => {
+      await daemon.stop()
     })
 
     afterEach(async () => {
@@ -190,28 +190,25 @@ describe('daemon dht client', function () {
   })
 
   describe('findPeer', () => {
-    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock', 9090)
     let daemonA
     let daemonB
     let client
 
-    before(function () {
-      return Promise.all([
+    before(async function () {
+      [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
-      ]).then((res) => {
-        daemonA = res[0]
-        daemonB = res[1]
+      ])
 
-        return Promise.all([
-          daemonA.start(),
-          daemonB.start()
-        ])
-      })
+      await Promise.all([
+        daemonA.start(),
+        daemonB.start()
+      ])
     })
 
-    after(function () {
-      return Promise.all([
+    after(async function () {
+      await Promise.all([
         daemonA.stop(),
         daemonB.stop()
       ])
@@ -234,7 +231,7 @@ describe('daemon dht client', function () {
       }
 
       // close first client
-      client.close()
+      await client.close()
 
       client = new Client(addr2)
 
@@ -297,8 +294,8 @@ describe('daemon dht client', function () {
       await daemon.start()
     })
 
-    after(() => {
-      return daemon.stop()
+    after(async () => {
+      await daemon.stop()
     })
 
     afterEach(async () => {
@@ -341,8 +338,6 @@ describe('daemon dht client', function () {
       } finally {
         stub.restore()
       }
-
-      await client.close()
     })
 
     it('should error if it gets an invalid cid', async () => {
@@ -368,8 +363,8 @@ describe('daemon dht client', function () {
       await daemon.start()
     })
 
-    after(() => {
-      return daemon.stop()
+    after(async () => {
+      await daemon.stop()
     })
 
     afterEach(async () => {
@@ -440,30 +435,27 @@ describe('daemon dht client', function () {
   })
 
   describe('getClosestPeers', () => {
-    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock', 9090)
     let daemonA
     let daemonB
     let client
 
     const key = 'foobar'
 
-    before(function () {
-      return Promise.all([
+    before(async function () {
+      [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
-      ]).then((res) => {
-        daemonA = res[0]
-        daemonB = res[1]
+      ])
 
-        return Promise.all([
-          daemonA.start(),
-          daemonB.start()
-        ])
-      })
+      await Promise.all([
+        daemonA.start(),
+        daemonB.start()
+      ])
     })
 
-    after(function () {
-      return Promise.all([
+    after(async function () {
+      await Promise.all([
         daemonA.stop(),
         daemonB.stop()
       ])
@@ -502,7 +494,7 @@ describe('daemon dht client', function () {
       }
 
       // close first client
-      client.close()
+      await client.close()
 
       client = new Client(addr2)
       await client.attach()
@@ -549,24 +541,21 @@ describe('daemon dht client', function () {
   })
 
   describe('getPublicKey', () => {
-    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock', 9090)
     let daemonA
     let daemonB
     let client
 
-    before(function () {
-      return Promise.all([
+    before(async function () {
+      [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
-      ]).then((res) => {
-        daemonA = res[0]
-        daemonB = res[1]
+      ])
 
-        return Promise.all([
-          daemonA.start(),
-          daemonB.start()
-        ])
-      })
+      await Promise.all([
+        daemonA.start(),
+        daemonB.start()
+      ])
     })
 
     after(function () {
@@ -593,7 +582,7 @@ describe('daemon dht client', function () {
       }
 
       // close first client
-      client.close()
+      await client.close()
 
       client = new Client(addr2)
 

--- a/test/dht.spec.js
+++ b/test/dht.spec.js
@@ -17,13 +17,13 @@ const { Response } = require('libp2p-daemon/src/protocol')
 const CID = require('cids')
 const PeerID = require('peer-id')
 
-const { getSockPath } = require('./utils')
-const defaultSock = getSockPath('/tmp/p2pd.sock')
+const { getMultiaddr } = require('./utils')
+const defaultMultiaddr = getMultiaddr('/tmp/p2pd.sock')
 
 describe('daemon dht client', function () {
   this.timeout(30e3)
 
-  const daemonOpts = (sock) => ({
+  const daemonOpts = (addr) => ({
     quiet: false,
     q: false,
     bootstrap: false,
@@ -31,7 +31,7 @@ describe('daemon dht client', function () {
     dht: true,
     dhtClient: true,
     connMgr: false,
-    sock: sock || defaultSock,
+    listen: addr || defaultMultiaddr.toString(),
     id: '',
     bootstrapPeers: ''
   })
@@ -53,7 +53,7 @@ describe('daemon dht client', function () {
     })
 
     it('should be able to put a value to the dth', async function () {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -67,7 +67,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if receive an error message', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -91,7 +91,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if receive an invalid key', async function () {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -106,7 +106,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if receive an invalid value', async function () {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -142,7 +142,7 @@ describe('daemon dht client', function () {
       const key = '/key'
       const value = Buffer.from('oh hello there')
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -164,7 +164,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if receive an invalid key', async function () {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -177,7 +177,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it cannot get a value', async function () {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -190,7 +190,7 @@ describe('daemon dht client', function () {
   })
 
   describe('findPeer', () => {
-    const sock2 = getSockPath('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
     let daemonA
     let daemonB
     let client
@@ -198,7 +198,7 @@ describe('daemon dht client', function () {
     before(function () {
       return Promise.all([
         createDaemon(daemonOpts()),
-        createDaemon(daemonOpts(sock2))
+        createDaemon(daemonOpts(addr2.toString()))
       ]).then((res) => {
         daemonA = res[0]
         daemonB = res[1]
@@ -222,7 +222,7 @@ describe('daemon dht client', function () {
     })
 
     it('should be able to find a peer', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -236,7 +236,7 @@ describe('daemon dht client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -259,7 +259,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it gets an invalid peerId', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -274,7 +274,7 @@ describe('daemon dht client', function () {
     it('should error if it cannot find the peer', async () => {
       PeerID.create({ bits: 512 }, async (err, peerId) => {
         expect(err).to.not.exist()
-        client = new Client(defaultSock)
+        client = new Client(defaultMultiaddr)
 
         await client.attach()
 
@@ -308,7 +308,7 @@ describe('daemon dht client', function () {
     it('should be able to provide', async () => {
       const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp38')
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -322,7 +322,7 @@ describe('daemon dht client', function () {
     it('should error if receive an error message', async () => {
       const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp38')
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -346,7 +346,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it gets an invalid cid', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -378,7 +378,7 @@ describe('daemon dht client', function () {
 
     it('should receive empty providers if no provider for the cid exists', async () => {
       const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp39')
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -396,7 +396,7 @@ describe('daemon dht client', function () {
     it('should be able to find providers', async () => {
       const cid = new CID('QmVzw6MPsF96TyXBSRs1ptLoVMWRv5FCYJZZGJSVB2Hp38')
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -426,7 +426,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it gets an invalid cid', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -440,7 +440,7 @@ describe('daemon dht client', function () {
   })
 
   describe('getClosestPeers', () => {
-    const sock2 = getSockPath('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
     let daemonA
     let daemonB
     let client
@@ -450,7 +450,7 @@ describe('daemon dht client', function () {
     before(function () {
       return Promise.all([
         createDaemon(daemonOpts()),
-        createDaemon(daemonOpts(sock2))
+        createDaemon(daemonOpts(addr2.toString()))
       ]).then((res) => {
         daemonA = res[0]
         daemonB = res[1]
@@ -474,7 +474,7 @@ describe('daemon dht client', function () {
     })
 
     it('should get an empty array if it does not know any peer', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -490,7 +490,7 @@ describe('daemon dht client', function () {
     })
 
     it('should be able to get the closest peers', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -504,7 +504,7 @@ describe('daemon dht client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
       await client.attach()
 
       try {
@@ -535,7 +535,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it gets an invalid key', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -549,7 +549,7 @@ describe('daemon dht client', function () {
   })
 
   describe('getPublicKey', () => {
-    const sock2 = getSockPath('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
     let daemonA
     let daemonB
     let client
@@ -557,7 +557,7 @@ describe('daemon dht client', function () {
     before(function () {
       return Promise.all([
         createDaemon(daemonOpts()),
-        createDaemon(daemonOpts(sock2))
+        createDaemon(daemonOpts(addr2.toString()))
       ]).then((res) => {
         daemonA = res[0]
         daemonB = res[1]
@@ -581,7 +581,7 @@ describe('daemon dht client', function () {
     })
 
     it('should be able to get the public key', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -595,7 +595,7 @@ describe('daemon dht client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -619,7 +619,7 @@ describe('daemon dht client', function () {
     it('should error if it cannot find the peer', async () => {
       PeerID.create({ bits: 512 }, async (err, peerId) => {
         expect(err).to.not.exist()
-        client = new Client(defaultSock)
+        client = new Client(defaultMultiaddr)
 
         await client.attach()
 
@@ -632,7 +632,7 @@ describe('daemon dht client', function () {
     })
 
     it('should error if it receives an invalid peerId', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,13 +13,13 @@ const { Response } = require('libp2p-daemon/src/protocol')
 
 const PeerId = require('peer-id')
 
-const { getSockPath } = require('./utils')
-const defaultSock = getSockPath('/tmp/p2pd.sock')
+const { getMultiaddr } = require('./utils')
+const defaultMultiaddr = getMultiaddr('/tmp/p2pd.sock')
 
 describe('daemon client', function () {
   this.timeout(30e3)
 
-  const daemonOpts = (sock) => ({
+  const daemonOpts = (addr) => ({
     quiet: false,
     q: false,
     bootstrap: false,
@@ -27,7 +27,7 @@ describe('daemon client', function () {
     dht: false,
     dhtClient: false,
     connMgr: false,
-    sock: sock || defaultSock,
+    listen: addr || defaultMultiaddr.toString(),
     id: '',
     bootstrapPeers: ''
   })
@@ -37,7 +37,8 @@ describe('daemon client', function () {
     let client
 
     before(function () {
-      createDaemon(daemonOpts()).then((res) => {
+      let opts = daemonOpts()
+      createDaemon(opts).then((res) => {
         daemon = res
 
         return daemon.start()
@@ -53,7 +54,7 @@ describe('daemon client', function () {
     })
 
     it('should be able to identify', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -78,7 +79,7 @@ describe('daemon client', function () {
         }
       })
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -94,7 +95,7 @@ describe('daemon client', function () {
   })
 
   describe('listPeers', () => {
-    const sock2 = getSockPath('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
     let daemonA
     let daemonB
     let client
@@ -102,7 +103,7 @@ describe('daemon client', function () {
     before(function () {
       return Promise.all([
         createDaemon(daemonOpts()),
-        createDaemon(daemonOpts(sock2))
+        createDaemon(daemonOpts(addr2.toString()))
       ]).then((res) => {
         daemonA = res[0]
         daemonB = res[1]
@@ -126,7 +127,7 @@ describe('daemon client', function () {
     })
 
     it('should be able to listPeers', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -140,7 +141,7 @@ describe('daemon client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -180,7 +181,7 @@ describe('daemon client', function () {
         }
       })
 
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -196,7 +197,7 @@ describe('daemon client', function () {
   })
 
   describe('connect', () => {
-    const sock2 = getSockPath('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
     let daemonA
     let daemonB
     let client
@@ -204,7 +205,7 @@ describe('daemon client', function () {
     before(function () {
       return Promise.all([
         createDaemon(daemonOpts()),
-        createDaemon(daemonOpts(sock2))
+        createDaemon(daemonOpts(addr2.toString()))
       ]).then((res) => {
         daemonA = res[0]
         daemonB = res[1]
@@ -228,7 +229,7 @@ describe('daemon client', function () {
     })
 
     it('should be able to connect', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -242,7 +243,7 @@ describe('daemon client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -254,7 +255,7 @@ describe('daemon client', function () {
     })
 
     it('should error if receive an error message', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -275,7 +276,7 @@ describe('daemon client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -290,7 +291,7 @@ describe('daemon client', function () {
     })
 
     it('should error if receive an invalid peerid', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -303,7 +304,7 @@ describe('daemon client', function () {
     })
 
     it('should error if addrs received are not in an array', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -317,7 +318,7 @@ describe('daemon client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 
@@ -330,7 +331,7 @@ describe('daemon client', function () {
     })
 
     it('should error if any addrs received is not a multiaddr', async () => {
-      client = new Client(defaultSock)
+      client = new Client(defaultMultiaddr)
 
       await client.attach()
 
@@ -344,7 +345,7 @@ describe('daemon client', function () {
       // close first client
       client.close()
 
-      client = new Client(sock2)
+      client = new Client(addr2)
 
       await client.attach()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -47,17 +47,14 @@ describe('daemon client', function () {
     let daemon
     let client
 
-    before(function () {
+    before(async function () {
       let opts = daemonOpts()
-      createDaemon(opts).then((res) => {
-        daemon = res
-
-        return daemon.start()
-      })
+      daemon = await createDaemon(opts)
+      await daemon.start()
     })
 
-    after(() => {
-      return daemon.stop()
+    after(async () => {
+      await daemon.stop()
     })
 
     afterEach(async () => {
@@ -106,28 +103,25 @@ describe('daemon client', function () {
   })
 
   describe('listPeers', () => {
-    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock', 9090)
     let daemonA
     let daemonB
     let client
 
-    before(function () {
-      return Promise.all([
+    before(async () => {
+      [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
-      ]).then((res) => {
-        daemonA = res[0]
-        daemonB = res[1]
+      ])
 
-        return Promise.all([
-          daemonA.start(),
-          daemonB.start()
-        ])
-      })
+      await Promise.all([
+        daemonA.start(),
+        daemonB.start()
+      ])
     })
 
-    after(function () {
-      return Promise.all([
+    after(async () => {
+      await Promise.all([
         daemonA.stop(),
         daemonB.stop()
       ])
@@ -208,28 +202,24 @@ describe('daemon client', function () {
   })
 
   describe('connect', () => {
-    const addr2 = getMultiaddr('/tmp/p2pd-2.sock')
+    const addr2 = getMultiaddr('/tmp/p2pd-2.sock', 9090)
     let daemonA
     let daemonB
     let client
 
-    before(function () {
-      return Promise.all([
+    before(async () => {
+      [daemonA, daemonB] = await Promise.all([
         createDaemon(daemonOpts()),
         createDaemon(daemonOpts(addr2.toString()))
-      ]).then((res) => {
-        daemonA = res[0]
-        daemonB = res[1]
-
-        return Promise.all([
-          daemonA.start(),
-          daemonB.start()
-        ])
-      })
+      ])
+      await Promise.all([
+        daemonA.start(),
+        daemonB.start()
+      ])
     })
 
-    after(function () {
-      return Promise.all([
+    after(async () => {
+      await Promise.all([
         daemonA.stop(),
         daemonB.stop()
       ])

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -93,6 +93,7 @@ describe('daemon client', function () {
 
       try {
         await client.identify()
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.toString()).to.equal('Error: mock error')
@@ -192,6 +193,7 @@ describe('daemon client', function () {
 
       try {
         await client.listPeers()
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.code).to.equal('ERR_LIST_PEERS_FAILED')
@@ -283,6 +285,7 @@ describe('daemon client', function () {
 
       try {
         await client.connect(identify.peerId, identify.addrs)
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.toString()).to.equal('Error: mock error')
@@ -298,6 +301,7 @@ describe('daemon client', function () {
 
       try {
         await client.connect('peerId')
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.code).to.equal('ERR_INVALID_PEER_ID')
@@ -325,6 +329,7 @@ describe('daemon client', function () {
 
       try {
         await client.connect(identify.peerId, 'addrs')
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.code).to.equal('ERR_INVALID_ADDRS_TYPE')
@@ -352,6 +357,7 @@ describe('daemon client', function () {
 
       try {
         await client.connect(identify.peerId, ['addrs'])
+        expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
         expect(err.code).to.equal('ERR_NO_MULTIADDR_RECEIVED')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -32,6 +32,17 @@ describe('daemon client', function () {
     bootstrapPeers: ''
   })
 
+  it('should be able to start a server', async () => {
+    const client1 = new Client(getMultiaddr('/tmp/p2pd.sock'))
+    const client2 = new Client(getMultiaddr('/tmp/p2pd2.sock'))
+
+    await client1.startServer(getMultiaddr('/tmp/p2pd2.sock'), (conn) => conn.pipe(conn))
+
+    await client2.attach()
+    await client2.close()
+    await client1.stopServer()
+  })
+
   describe('identify', () => {
     let daemon
     let client

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,6 +2,7 @@
 
 const os = require('os')
 const path = require('path')
+const ma = require('multiaddr')
 const isWindows = Boolean(os.type().match(/windows/gi))
 
 exports.getSockPath = (sockPath) => isWindows
@@ -9,3 +10,7 @@ exports.getSockPath = (sockPath) => isWindows
   : path.resolve(os.tmpdir(), sockPath)
 
 exports.isWindows = isWindows
+
+exports.getMultiaddr = (sockPath) => isWindows
+  ? ma('/ip4/0.0.0.0/tcp/8080')
+  : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,6 +11,6 @@ exports.getSockPath = (sockPath) => isWindows
 
 exports.isWindows = isWindows
 
-exports.getMultiaddr = (sockPath) => isWindows
-  ? ma('/ip4/0.0.0.0/tcp/8080')
+exports.getMultiaddr = (sockPath, port) => isWindows
+  ? ma(`/ip4/0.0.0.0/tcp/${port || 8080}`)
   : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,6 +3,7 @@
 const os = require('os')
 const path = require('path')
 const ma = require('multiaddr')
+const PeerID = require('peer-id')
 const isWindows = Boolean(os.type().match(/windows/gi))
 
 exports.getSockPath = (sockPath) => isWindows
@@ -14,3 +15,15 @@ exports.isWindows = isWindows
 exports.getMultiaddr = (sockPath, port) => isWindows
   ? ma(`/ip4/0.0.0.0/tcp/${port || 8080}`)
   : ma(`/unix${path.resolve(os.tmpdir(), sockPath)}`)
+
+/**
+ * @returns {Promise} Returns the generated `PeerId`
+ */
+exports.createPeerId = () => {
+  return new Promise((resolve, reject) => {
+    PeerID.create({ bits: 512 }, async (err, peerId) => {
+      if (err) return reject(err)
+      resolve(peerId)
+    })
+  })
+}


### PR DESCRIPTION
This switches over to the latest daemon updates, which leverage multiaddrs instead of paths.

This also includes some correction to tests. When tests were expecting an error to exist inside a `catch`, if the `try` didn't error the expects would never be called. Those tests now have `expect.fail()` calls after the expected failure to ensure the `catch` is triggered.

- [x] depends on https://github.com/libp2p/js-libp2p-daemon/pull/10