### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 libp2p-daemon client JavaScript implementation
 ======
 
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai/)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+
 > A Javascript client to interact with a standalone deployment of a libp2p host, running in its own OS process. Essentially, this client allows to communicate with other peers, interact with the DHT, participate in pubsub, etc. no matter the language they are implemented with.
 
 ## Lead Maintainer

--- a/package.json
+++ b/package.json
@@ -30,19 +30,19 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "aegir": "^17.1.1",
+    "aegir": "^18.2.1",
     "chai": "^4.2.0",
     "chai-bytes": "~0.1.2",
     "dirty-chai": "^2.0.1",
-    "mocha": "^5.2.0",
-    "sinon": "^7.2.2"
+    "mocha": "^6.1.2",
+    "sinon": "^7.3.1"
   },
   "dependencies": {
-    "cids": "~0.5.7",
+    "cids": "~0.6.0",
     "err-code": "^1.1.2",
     "length-prefixed-stream": "github:jacobheun/length-prefixed-stream#v2.0.0-rc.1",
     "libp2p-daemon": "~0.2.0",
-    "multiaddr": "^6.0.5",
+    "multiaddr": "^6.0.6",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "stream-to-iterator": "^3.0.2-0"


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated