### PR TITLE
Client.connect: Handle unspecified error in response

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "aegir": "^18.2.1",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "chai-bytes": "~0.1.2",
     "dirty-chai": "^2.0.1",
     "mocha": "^6.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,8 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.error.msg, 'ERR_CONNECT_FAILED')
+      const errResponse = response.error || {}
+      throw errcode(errResponse.msg || 'unspecified', 'ERR_CONNECT_FAILED')
     }
   }
 


### PR DESCRIPTION
I noticed when testing in [libp2p/interop](http://github.com/libp2p/interop/), that this library would sometimes fail in `Client.connect` due to an undefined `ErrorResponse` in the response. With this PR I try to handle this case gracefully. I observed that the error could have an `error` property instead, so I added tests both for when `error` is defined and when neither that not `ErrorResponse` is present.

I also added chai-as-promised as a dev dependency, in order to test async errors more cleanly (without boilerplate).