### PR TITLE
bug: stop using ErrorResponse as field name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.ErrorResponse.msg, 'ERR_CONNECT_FAILED')
+      throw errcode(response.error.msg, 'ERR_CONNECT_FAILED')
     }
   }
 
@@ -187,7 +187,7 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.ErrorResponse.msg, 'ERR_IDENTIFY_FAILED')
+      throw errcode(response.error.msg, 'ERR_IDENTIFY_FAILED')
     }
 
     const peerId = PeerID.createFromBytes(response.identify.id)
@@ -209,7 +209,7 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.ErrorResponse.msg, 'ERR_LIST_PEERS_FAILED')
+      throw errcode(response.error.msg, 'ERR_LIST_PEERS_FAILED')
     }
 
     return response.peers.map((peer) => PeerID.createFromBytes(peer.id))
@@ -242,7 +242,7 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.ErrorResponse.msg, 'ERR_OPEN_STREAM_FAILED')
+      throw errcode(response.error.msg, 'ERR_OPEN_STREAM_FAILED')
     }
 
     return this.socket
@@ -276,7 +276,7 @@ class Client {
     const response = Response.decode(message)
 
     if (response.type !== Response.Type.OK) {
-      throw errcode(response.ErrorResponse.msg, 'ERR_REGISTER_STREAM_HANDLER_FAILED')
+      throw errcode(response.error.msg, 'ERR_REGISTER_STREAM_HANDLER_FAILED')
     }
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -82,7 +82,7 @@ describe('daemon client', function () {
     it('should error if receive an error message', async () => {
       const stub = sinon.stub(Response, 'decode').returns({
         type: 'ERROR',
-        ErrorResponse: {
+        error: {
           msg: 'mock error'
         }
       })
@@ -182,7 +182,7 @@ describe('daemon client', function () {
     it('should error if receive an error message', async () => {
       const stub = sinon.stub(Response, 'decode').returns({
         type: 'ERROR',
-        ErrorResponse: {
+        error: {
           msg: 'mock error'
         }
       })
@@ -271,7 +271,7 @@ describe('daemon client', function () {
 
       const stub = sinon.stub(Response, 'decode').returns({
         type: 'ERROR',
-        ErrorResponse: {
+        error: {
           msg: 'mock error'
         }
       })


### PR DESCRIPTION
`ErrorResponse` is the type, `error` is the field name