### PR TITLE
chore: remove peer-info from api

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "err-code": "^2.0.0",
     "it-handshake": "^1.0.1",
     "it-length-prefixed": "^3.0.0",
-    "libp2p-daemon": "libp2p/js-libp2p-daemon#chore/update-peer-store-api",
+    "libp2p-daemon": "^0.4.0",
     "libp2p-tcp": "^0.14.2",
     "multiaddr": "^7.2.1",
     "peer-id": "~0.13.3"

--- a/package.json
+++ b/package.json
@@ -51,11 +51,10 @@
     "err-code": "^2.0.0",
     "it-handshake": "^1.0.1",
     "it-length-prefixed": "^3.0.0",
-    "libp2p-daemon": "^0.3.0",
+    "libp2p-daemon": "libp2p/js-libp2p-daemon#chore/update-peer-store-api",
     "libp2p-tcp": "^0.14.2",
     "multiaddr": "^7.2.1",
-    "peer-id": "~0.13.3",
-    "peer-info": "~0.17.0"
+    "peer-id": "~0.13.3"
   },
   "contributors": [
     "Arve Knudsen <arve.knudsen@gmail.com>",


### PR DESCRIPTION
In the context of the PeerStore improvements specified on [libp2p/js-libp2p#582](https://github.com/libp2p/js-libp2p/issues/582) and as a follow up of [libp2p/js-libp2p#590](https://github.com/libp2p/js-libp2p/pull/590).

This PR changes to the new `libp2p` API with no `peer-info`

The modules changed (`libp2p` and `libp2p-kad-dht`) were updated.

Needs:

- [x] [libp2p/js-libp2p#610](https://github.com/libp2p/js-libp2p/pull/610)
- [x] [libp2p/js-libp2p-daemon#38](https://github.com/libp2p/js-libp2p-daemon/pull/38)