### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/API.md
+++ b/API.md
@@ -90,7 +90,7 @@ const client = new Client(defaultSock)
 try {
   await client.connect(peerId, addrs)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -118,7 +118,7 @@ let identify
 try {
   identify = await client.identify()
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -145,7 +145,7 @@ let identify
 try {
   identify = await client.identify()
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -182,7 +182,7 @@ try {
   //
 }
 
-socket.write(Buffer.from('data'))
+socket.write(uint8ArrayFromString('data'))
 ```
 
 ## registerStreamHandler
@@ -217,8 +217,8 @@ Write a value to a key in the DHT.
 
 | Name | Type | Description |
 |------|------|-------------|
-| key | `String` | key to add to the dht |
-| value | `Buffer` | value to add to the dht |
+| key | `Uint8Array` | key to add to the dht |
+| value | `Uint8Array` | value to add to the dht |
 
 #### Example
 
@@ -226,12 +226,12 @@ Write a value to a key in the DHT.
 const client = new Client(defaultSock)
 
 const key = '/key'
-const value = Buffer.from('oh hello there')
+const value = uint8ArrayFromString('oh hello there')
 
 try {
   await client.dht.put(key, value)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -245,13 +245,13 @@ Query the DHT for a value stored through a key in the DHT.
 
 | Name | Type | Description |
 |------|------|-------------|
-| key | `String` | key to get from the dht |
+| key | `Uint8Array` | key to get from the dht |
 
 #### Returns
 
 | Type | Description |
 |------|-------------|
-| `Buffer` | Value obtained from the DHT |
+| `Uint8Array` | Value obtained from the DHT |
 
 #### Example
 
@@ -264,7 +264,7 @@ let value
 try {
   value = await client.dht.get(key, value)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -296,7 +296,7 @@ let peerInfo
 try {
   peerInfo = await client.dht.findPeer(peerId)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -320,7 +320,7 @@ const client = new Client(defaultSock)
 try {
   await client.dht.provide(cid)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -354,7 +354,7 @@ let peerInfos
 try {
   peerInfos = await client.dht.findProviders(cid)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -368,7 +368,7 @@ Query the DHT routing table for peers that are closest to a provided key.
 
 | Name | Type | Description |
 |------|------|-------------|
-| key | `String` | key to get from the dht |
+| key | `Uint8Array` | key to get from the dht |
 
 #### Returns
 
@@ -387,7 +387,7 @@ let peerInfos
 try {
   peerInfos = await client.dht.getClosestPeers(key)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -419,7 +419,7 @@ let publicKey
 try {
   publicKey = await client.dht.getPublicKey(peerId)
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -441,7 +441,7 @@ let topics
 try {
   topics = await client.pubsub.getTopics()
 } catch (err) {
-  // 
+  //
 }
 ```
 
@@ -452,7 +452,7 @@ try {
 | Name | Type | Description |
 |------|------|-------------|
 | topic | `string` | topic to publish |
-| data | `Buffer` | data to publish  |
+| data | `Uint8Array` | data to publish  |
 
 #### Returns
 
@@ -464,13 +464,13 @@ try {
 
 ```js
 const topic = 'topic'
-const data = Buffer.from('data')
+const data = uint8ArrayFromString('data')
 const client = new Client(defaultSock)
 
 try {
   await client.pubsub.publish(topic, data)
 } catch (err) {
-  // 
+  //
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "err-code": "^2.0.0",
     "it-handshake": "^1.0.1",
     "it-length-prefixed": "^3.0.0",
-    "libp2p-daemon": "libp2p/js-libp2p-daemon#fix/replace-node-streams-with-uint8arrays",
+    "libp2p-daemon": "^0.5.0",
     "libp2p-tcp": "^0.15.1",
     "multiaddr": "^8.0.0",
     "peer-id": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "aegir": "^24.0.0",
+    "aegir": "^26.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-bytes": "~0.1.2",
@@ -44,17 +44,18 @@
     "it-pushable": "^1.4.0",
     "mocha": "^8.0.1",
     "sinon": "^9.0.0",
-    "streaming-iterables": "^5.0.2"
+    "streaming-iterables": "^5.0.2",
+    "uint8arrays": "^1.1.0"
   },
   "dependencies": {
-    "cids": "~0.8.0",
+    "cids": "^1.0.0",
     "err-code": "^2.0.0",
     "it-handshake": "^1.0.1",
     "it-length-prefixed": "^3.0.0",
-    "libp2p-daemon": "^0.4.0",
-    "libp2p-tcp": "^0.14.2",
-    "multiaddr": "^7.2.1",
-    "peer-id": "~0.13.3"
+    "libp2p-daemon": "libp2p/js-libp2p-daemon#fix/replace-node-streams-with-uint8arrays",
+    "libp2p-tcp": "^0.15.1",
+    "multiaddr": "^8.0.0",
+    "peer-id": "^0.14.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>",

--- a/src/dht.js
+++ b/src/dht.js
@@ -23,16 +23,16 @@ class DHT {
 
   /**
    * Write a value to a key in the DHT.
-   * @param {String} key
-   * @param {Buffer} value
+   * @param {Uint8Array} key
+   * @param {Uint8Array} value
    */
   async put (key, value) {
-    if (typeof key !== 'string') {
+    if (!(key instanceof Uint8Array)) {
       throw errcode(new Error('invalid key received'), 'ERR_INVALID_KEY')
     }
 
-    if (!Buffer.isBuffer(value)) {
-      throw errcode(new Error('value received is not a buffer'), 'ERR_INVALID_VALUE')
+    if (!(value instanceof Uint8Array)) {
+      throw errcode(new Error('value received is not a Uint8Array'), 'ERR_INVALID_VALUE')
     }
 
     const sh = await this._client.send({
@@ -56,11 +56,11 @@ class DHT {
 
   /**
    * Query the DHT for a value stored at a key in the DHT.
-   * @param {String} key
-   * @returns {Buffer}
+   * @param {Uint8Array} key
+   * @returns {Uint8Array}
    */
   async get (key) {
-    if (typeof key !== 'string') {
+    if (!(key instanceof Uint8Array)) {
       throw errcode(new Error('invalid key received'), 'ERR_INVALID_KEY')
     }
 
@@ -130,7 +130,7 @@ class DHT {
       type: Request.Type.DHT,
       dht: {
         type: DHTRequest.Type.PROVIDE,
-        cid: cid.buffer
+        cid: cid.bytes
       }
     })
 
@@ -159,7 +159,7 @@ class DHT {
       type: Request.Type.DHT,
       dht: {
         type: DHTRequest.Type.FIND_PROVIDERS,
-        cid: cid.buffer,
+        cid: cid.bytes,
         count
       }
     })
@@ -200,11 +200,11 @@ class DHT {
 
   /**
    * Query the DHT routing table for peers that are closest to a provided key.
-   * @param {string} key
+   * @param {Uint8Array} key
    * @returns {Array<PeerInfo>}
    */
   async * getClosestPeers (key) {
-    if (typeof key !== 'string') {
+    if (!(key instanceof Uint8Array)) {
       throw errcode(new Error('invalid key received'), 'ERR_INVALID_KEY')
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ class Client {
       type: Request.Type.CONNECT,
       connect: {
         peer: peerId.toBytes(),
-        addrs: addrs.map((a) => a.buffer)
+        addrs: addrs.map((a) => a.bytes)
       }
     })
 
@@ -186,7 +186,7 @@ class Client {
     const sh = await this.send({
       type: Request.Type.STREAM_OPEN,
       streamOpen: {
-        peer: Buffer.from(peerId.toB58String()),
+        peer: peerId.toBytes(),
         proto: [protocol]
       }
     })
@@ -221,7 +221,7 @@ class Client {
       type: Request.Type.STREAM_HANDLER,
       streamOpen: null,
       streamHandler: {
-        addr: addr.buffer,
+        addr: addr.bytes,
         proto: [protocol]
       }
     })

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -52,8 +52,8 @@ class Pubsub {
       throw errcode(new Error('invalid topic received'), 'ERR_INVALID_TOPIC')
     }
 
-    if (!Buffer.isBuffer(data)) {
-      throw errcode(new Error('data received is not a buffer'), 'ERR_INVALID_DATA')
+    if (!(data instanceof Uint8Array)) {
+      throw errcode(new Error('data received is not a Uint8Array'), 'ERR_INVALID_DATA')
     }
 
     const sh = await this._client.send({

--- a/test/dht.spec.js
+++ b/test/dht.spec.js
@@ -9,6 +9,7 @@ chai.use(dirtyChai)
 chai.use(chaiBytes)
 
 const sinon = require('sinon')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const { createDaemon } = require('libp2p-daemon/src/daemon')
 const Client = require('../src')
@@ -40,8 +41,8 @@ describe('daemon dht client', function () {
     let daemon
     let client
 
-    const key = '/key'
-    const value = Buffer.from('oh hello there')
+    const key = uint8ArrayFromString('/key')
+    const value = uint8ArrayFromString('oh hello there')
 
     before(async function () {
       daemon = await createDaemon(daemonOpts())
@@ -52,7 +53,7 @@ describe('daemon dht client', function () {
       return daemon.stop()
     })
 
-    it('should be able to put a value to the dth', async function () {
+    it('should be able to put a value to the dht', async function () {
       client = new Client(defaultMultiaddr)
 
       try {
@@ -91,7 +92,7 @@ describe('daemon dht client', function () {
       client = new Client(defaultMultiaddr)
 
       try {
-        await client.dht.put(value, value)
+        await client.dht.put(5, value)
         expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
@@ -105,7 +106,7 @@ describe('daemon dht client', function () {
       client = new Client(defaultMultiaddr)
 
       try {
-        await client.dht.put(key, key)
+        await client.dht.put(key, 5)
         expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
@@ -134,8 +135,8 @@ describe('daemon dht client', function () {
     })
 
     it('should be able to get a value from the dth', async function () {
-      const key = '/key'
-      const value = Buffer.from('oh hello there')
+      const key = uint8ArrayFromString('/key')
+      const value = uint8ArrayFromString('oh hello there')
 
       client = new Client(defaultMultiaddr)
 
@@ -160,7 +161,7 @@ describe('daemon dht client', function () {
       client = new Client(defaultMultiaddr)
 
       try {
-        await client.dht.get(Buffer.from('/key'))
+        await client.dht.get(uint8ArrayFromString('/key'))
         expect('should have thrown')
       } catch (err) {
         expect(err).to.exist()
@@ -172,7 +173,7 @@ describe('daemon dht client', function () {
       client = new Client(defaultMultiaddr)
 
       try {
-        await client.dht.get('/unavailable-key')
+        await client.dht.get(uint8ArrayFromString('/unavailable-key'))
         expect.fail('should have thrown')
       } catch (err) {
         expect(err).to.exist()
@@ -418,7 +419,7 @@ describe('daemon dht client', function () {
     let daemonB
     let client
 
-    const key = 'foobar'
+    const key = uint8ArrayFromString('foobar')
 
     before(async function () {
       [daemonA, daemonB] = await Promise.all([

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -9,6 +9,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 chai.use(chaiBytes)
 
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const { Response } = require('libp2p-daemon/src/protocol')
 const { createDaemon } = require('libp2p-daemon/src/daemon')
 const Client = require('../src')
@@ -127,7 +128,7 @@ describe('daemon pubsub client', function () {
 
     it('should subscribe to messages and receive them when published', async () => {
       const topic = 'test-topic'
-      const data = Buffer.from('test-data')
+      const data = uint8ArrayFromString('test-data')
 
       client1 = new Client(defaultMultiaddr)
       client2 = new Client(addr2)
@@ -163,8 +164,8 @@ describe('daemon pubsub client', function () {
     })
 
     it('should error if publish receives an invalid topic', async () => {
-      const topic = Buffer.from('test-topic')
-      const data = Buffer.from('test-data')
+      const topic = uint8ArrayFromString('test-topic')
+      const data = uint8ArrayFromString('test-data')
 
       client1 = new Client(defaultMultiaddr)
 
@@ -194,7 +195,7 @@ describe('daemon pubsub client', function () {
 
     it('should error if publish receives an error message', async () => {
       const topic = 'test-topic'
-      const data = Buffer.from('test-data')
+      const data = uint8ArrayFromString('test-data')
 
       const stub = sinon.stub(Response, 'decode').returns({
         type: 'ERROR',
@@ -217,7 +218,7 @@ describe('daemon pubsub client', function () {
     })
 
     it('should error if subscribe receives an invalid topic', async () => {
-      const topic = Buffer.from('test-topic')
+      const topic = uint8ArrayFromString('test-topic')
 
       client1 = new Client(defaultMultiaddr)
 

--- a/test/stream.spec.js
+++ b/test/stream.spec.js
@@ -9,6 +9,7 @@ chai.use(dirtyChai)
 const pipe = require('it-pipe')
 const { collect, take } = require('streaming-iterables')
 const { toBuffer } = require('it-buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const Client = require('../src')
 const { createDaemon } = require('libp2p-daemon/src/daemon')
@@ -66,7 +67,7 @@ describe('daemon stream client', function () {
   })
 
   it('should be able to open a stream, write to it and a stream handler, should handle the message', async () => {
-    const data = Buffer.from('test-data')
+    const data = uint8ArrayFromString('test-data')
     const protocol = '/protocol/1.0.0'
     const socketAddr = getMultiaddr('/tmp/p2p-protocol-handler.sock', 9091)
 


### PR DESCRIPTION
BREAKING CHANGES:

- All deps of this module now use uint8arrays in place of node buffers
- DHT keys/values are Uint8Arrays, not Strings or Buffers