### PR TITLE
chore: update daemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "err-code": "^3.0.1",
     "it-handshake": "^2.0.0",
     "it-length-prefixed": "^5.0.2",
-    "libp2p-daemon": "^0.7.0",
+    "libp2p-daemon": "^0.8.0",
     "libp2p-tcp": "^0.17.1",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.4.2",


### PR DESCRIPTION
Updates the daemon dep to a new version.

The tests will not pass until a new libp2p is released, which needs this
module releasing before that can happen.